### PR TITLE
Adds mock app provider

### DIFF
--- a/client/src/AppProvider.tsx
+++ b/client/src/AppProvider.tsx
@@ -3,21 +3,18 @@ import './App.scss'
 
 import {TaskType} from "./types/";
 import {AppContext} from "./context";
-import {TaskInput} from "./components/TaskInput";
-import {List} from "./components/TaskList";
+import App from "./components/App.tsx";
 
-function App() {
+function AppProvider() {
     const [tasks, setTasks] = useState<TaskType[]>([])
 
     return (
         <div className="container mx-auto">
             <AppContext.Provider value={{tasks, setTasks}}>
-                <h1 className={`font-mono mb-4`}>Over-Engineered To Do App</h1>
-                <TaskInput/>
-                <List/>
+                <App/>
             </AppContext.Provider>
         </div>
     )
 }
 
-export default App
+export default AppProvider

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -1,0 +1,15 @@
+import '../App.scss'
+import {TaskInput} from "./TaskInput";
+import {List} from "./TaskList";
+
+function App() {
+    return (
+        <>
+            <h1 className={`font-mono mb-4`}>Over-Engineered To Do App</h1>
+            <TaskInput/>
+            <List/>
+        </>
+    )
+}
+
+export default App

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
 import './index.scss'
+import AppProvider from "./AppProvider.tsx";
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AppProvider />
   </React.StrictMode>,
 )

--- a/client/tests/App.test.tsx
+++ b/client/tests/App.test.tsx
@@ -1,6 +1,7 @@
 import {fireEvent, render, screen} from '@testing-library/react';
 
-import App from '../src/App';
+import App from '../src/components/App';
+import MockProvider from "./MockProvider";
 import * as React from "react";
 
 describe('App', () => {
@@ -10,18 +11,24 @@ describe('App', () => {
         expect(screen.getByText('Over-Engineered To Do App')).toBeInTheDocument();
     });
 
+    it('renders MockProvider component', () => {
+        render(<MockProvider/>);
+
+        expect(screen.getByText('Over-Engineered To Do App')).toBeInTheDocument();
+    });
+
     it('contains an Input component', () => {
-        const {getByTestId} = render(<App/>);
+        const {getByTestId} = render(<MockProvider/>);
         expect(getByTestId('task-input')).toBeInTheDocument();
     });
 
     it('contains a List of Tasks', () => {
-        const {getByTestId} = render(<App/>);
+        const {getByTestId} = render(<MockProvider/>);
         expect(getByTestId('task-list')).toBeInTheDocument();
     });
 
     it('adds items to the List', () => {
-        const {getByTestId} = render(<App/>);
+        const {getByTestId} = render(<MockProvider/>);
         const input = getByTestId('task-input') as HTMLInputElement;
         const button = getByTestId('task-submit') as HTMLButtonElement;
         const taskTitle = 'Go to the store'

--- a/client/tests/MockProvider.tsx
+++ b/client/tests/MockProvider.tsx
@@ -1,0 +1,28 @@
+import {useState} from 'react'
+import '../src/App.scss'
+
+import {TaskType} from "../src/types/";
+import {AppContext} from "../src/context";
+import App from "../src/components/App";
+
+
+const initialState:TaskType[] = [
+    {title: 'Go to the store', status: false},
+    {title: 'Buy some cheese', status: false},
+    {title: 'Buy a Vision Pro', status: true},
+    {title: 'Learn to fly', status: false},
+]
+
+function MockProvider() {
+    const [tasks, setTasks] = useState<TaskType[]>(initialState)
+
+    return (
+        <div className="container mx-auto">
+            <AppContext.Provider value={{tasks, setTasks}}>
+                <App/>
+            </AppContext.Provider>
+        </div>
+    )
+}
+
+export default MockProvider

--- a/client/tests/Task.test.tsx
+++ b/client/tests/Task.test.tsx
@@ -1,18 +1,19 @@
-import {fireEvent, render} from "@testing-library/react";
-import App from "../src/App";
+import {ByRoleOptions, fireEvent, render, within} from "@testing-library/react";
 import * as React from "react";
+import MockProvider from "./MockProvider";
 
 describe('Task', () => {
     it('can toggle the completed checkbox', () => {
-        const {getByTestId} = render(<App/>);
-        const input = getByTestId('task-input') as HTMLInputElement;
-        const button = getByTestId('task-submit') as HTMLButtonElement;
-        const taskTitle = 'Go to the store'
+        const {getByRole} = render(<MockProvider/>);
 
-        fireEvent.change(input, {target: {value: taskTitle}});
-        fireEvent.click(button)
+        const list = getByRole('list')
+        const { getAllByRole } = within(list)
 
-        const list = getByTestId('task-list') as HTMLElement
-        expect(list.textContent).toContain(taskTitle)
+        const items = getAllByRole("listitem")
+        const checkboxes = getAllByRole('checkbox', {container: items} as ByRoleOptions)
+
+        expect(checkboxes[1]).not.toBeChecked()
+        fireEvent.click(checkboxes[1])
+        expect(checkboxes[1]).toBeChecked()
     })
 })

--- a/client/tests/TaskInput.test.tsx
+++ b/client/tests/TaskInput.test.tsx
@@ -10,13 +10,22 @@ describe('Input', () => {
         expect(getByPlaceholderText('add your next task to do')).toBeInTheDocument();
     });
 
-    test('input field test', () => {
+    test('input field test with click', () => {
         const {getByTestId} = render(<TaskInput/>);
         const input = getByTestId('task-input') as HTMLInputElement;
         const button = getByTestId('task-submit') as HTMLButtonElement;
         fireEvent.change(input, {target: {value: 'test'}});
         expect(input.value).toBe('test');
         fireEvent.click(button)
+        expect(input.value).toBe('');
+    });
+
+    test('input field test with enter', () => {
+        const {getByTestId} = render(<TaskInput/>);
+        const input = getByTestId('task-input') as HTMLInputElement;
+        fireEvent.change(input, {target: {value: 'test'}});
+        expect(input.value).toBe('test');
+        fireEvent.keyDown(input, { key: 'Enter', code: 13, charCode: 13 });
         expect(input.value).toBe('');
     });
 });

--- a/client/tests/TaskList.test.tsx
+++ b/client/tests/TaskList.test.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import {render, within} from '@testing-library/react';
+
+import {List} from "../src/components/TaskList";
+import MockProvider from "./MockProvider";
+
+describe('List', () => {
+    it('contains a list html element', () => {
+        const {getByRole} = render(<List/>)
+        const list = getByRole('list')
+        expect(list).toBeInTheDocument()
+    })
+
+    it('contains lists items', () => {
+        const {getByRole} = render(<MockProvider/>);
+
+        const list = getByRole('list')
+        const { getAllByRole } = within(list)
+
+        const items = getAllByRole("listitem")
+
+        expect(items.length).toBe(4)
+    })
+});


### PR DESCRIPTION
The MockAppProvider allows for a default context so that tests can be more specific.

This is done by extracting out the App from the Provider, then I added an AppProvider and MockProvider.

The MockProvider has a default state.